### PR TITLE
Compatibility upgraded to HWI 2.0.2 binary along with fixes

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@ use std::process::{Command, Output};
 use bitcoin::util::bip32::{DerivationPath, Fingerprint};
 
 use crate::error::Error;
-use crate::types::HWIAddressType;
+use crate::types::{HWIAddressType, HWIChain};
 
 #[derive(Display)]
 pub enum HWISubcommand {
@@ -29,7 +29,8 @@ pub enum HWIFlag {
     DeviceType(String),
     Password(String),
     // TODO: StdinPass,
-    Testnet,
+    Chain(HWIChain),
+    AddrType(HWIAddressType),
     // TODO: Debug,
     Fingerprint(Fingerprint),
     // TODO: Version,
@@ -45,7 +46,10 @@ impl HWIFlag {
             HWIFlag::DeviceType(t) => vec![String::from("--device-type"), format!("{}", t)],
             HWIFlag::Password(p) => vec![String::from("--password"), format!("{}", p)],
             HWIFlag::Fingerprint(f) => vec![String::from("--fingerprint"), format!("{}", f)],
-            _ => vec![format!("--{:?}", self).to_lowercase()],
+            HWIFlag::Chain(chain) => vec![String::from("--chain"), format!("{:?}", chain).to_lowercase()],
+            HWIFlag::AddrType(a) => vec![String::from("--addr-type"), format!("{:?}", a).to_lowercase()],
+            // Required for unimplemented flags
+            // _ => vec![format!("--{:?}", self).to_lowercase()],
         }
     }
 }
@@ -86,11 +90,12 @@ impl HWICommand {
     /// # Examples
     /// ```
     /// use hwi::commands::{HWICommand, HWIFlag, HWISubcommand};
+    /// use hwi::types::HWIChain;
     ///
     /// let mut command = HWICommand::new();
     /// command
     ///     .add_subcommand(HWISubcommand::Enumerate)
-    ///     .add_flag(HWIFlag::Testnet);
+    ///     .add_flag(HWIFlag::Chain(HWIChain::Test));
     /// ```
     pub fn add_flag(&mut self, f: HWIFlag) -> &mut Self {
         self.command.args(f.to_args_vec());
@@ -148,15 +153,7 @@ impl HWICommand {
 
     /// Adds the address type flag to a HWICommand
     pub fn add_address_type(&mut self, address_type: HWIAddressType) -> &mut Self {
-        match address_type {
-            HWIAddressType::ShWpkh => {
-                self.command.arg("--sh_wpkh");
-            }
-            HWIAddressType::Wpkh => {
-                self.command.arg("--wpkh");
-            }
-            _ => {}
-        };
+        self.add_flag(HWIFlag::AddrType(address_type));
         self
     }
 
@@ -189,11 +186,9 @@ impl HWICommand {
         self
     }
 
-    /// Adds testnet flag to a HWICommand
-    pub fn add_testnet(&mut self, testnet: bool) -> &mut Self {
-        if testnet {
-            self.add_flag(HWIFlag::Testnet);
-        }
+    /// Adds chain flag and arguements to a HWICommand
+    pub fn add_chain(&mut self, chain: HWIChain) -> &mut Self {
+        self.add_flag(HWIFlag::Chain(chain));
         self
     }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -13,7 +13,7 @@ use crate::commands::{HWICommand, HWIFlag, HWISubcommand};
 use crate::error::Error;
 use crate::types::{
     HWIAddress, HWIAddressType, HWIDescriptor, HWIExtendedPubKey, HWIKeyPoolElement,
-    HWIPartiallySignedTransaction, HWISignature,
+    HWIPartiallySignedTransaction, HWISignature, HWIChain,
 };
 
 macro_rules! deserialize_obj {
@@ -48,10 +48,10 @@ impl HWIDevice {
     /// Returns the master xpub of a device.
     /// # Arguments
     /// * `testnet` - Whether to use testnet or not.
-    pub fn get_master_xpub(&self, testnet: bool) -> Result<HWIExtendedPubKey, Error> {
+    pub fn get_master_xpub(&self, chain: HWIChain) -> Result<HWIExtendedPubKey, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::GetMasterXpub)
             .execute()?;
         deserialize_obj!(&output.stdout)
@@ -64,12 +64,12 @@ impl HWIDevice {
     pub fn sign_tx(
         &self,
         psbt: &PartiallySignedTransaction,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWIPartiallySignedTransaction, Error> {
         let psbt = base64::encode(&serialize(psbt));
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::SignTx)
             .add_psbt(&psbt)
             .execute()?;
@@ -83,11 +83,11 @@ impl HWIDevice {
     pub fn get_xpub(
         &self,
         path: &DerivationPath,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWIExtendedPubKey, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::GetXpub)
             .add_path(&path, false, false)
             .execute()?;
@@ -103,11 +103,11 @@ impl HWIDevice {
         &self,
         message: &str,
         path: &DerivationPath,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWISignature, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::SignMessage)
             .add_message(&message)
             .add_path(&path, false, false)
@@ -134,12 +134,12 @@ impl HWIDevice {
         path: Option<&DerivationPath>,
         start: u32,
         end: u32,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<Vec<HWIKeyPoolElement>, Error> {
         let mut command = HWICommand::new();
         command
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::GetKeypool)
             .add_keypool(keypool)
             .add_internal(internal)
@@ -164,12 +164,12 @@ impl HWIDevice {
     pub fn get_descriptors(
         &self,
         account: Option<u32>,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWIDescriptor, Error> {
         let mut command = HWICommand::new();
         command
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::GetDescriptors);
 
         if let Some(a) = account {
@@ -187,11 +187,11 @@ impl HWIDevice {
     pub fn display_address_with_desc(
         &self,
         descriptor: &str,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWIAddress, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::DisplayAddress)
             .add_descriptor(&descriptor)
             .execute()?;
@@ -207,11 +207,11 @@ impl HWIDevice {
         &self,
         path: &DerivationPath,
         address_type: HWIAddressType,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWIAddress, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::DisplayAddress)
             .add_path(&path, true, false)
             .add_address_type(address_type)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,13 @@
 //!     let device = devices.first().unwrap();
 //!     let derivation_path = DerivationPath::from(vec![
 //!         ChildNumber::from_hardened_idx(44).unwrap(),
+//!         ChildNumber::from_hardened_idx(1).unwrap(),
+//!         ChildNumber::from_hardened_idx(0).unwrap(),
+//!         ChildNumber::from_normal_idx(0).unwrap(),
 //!         ChildNumber::from_normal_idx(0).unwrap(),
 //!     ]);
 //!
-//!     let hwi_address = device.display_address_with_path(&derivation_path, types::HWIAddressType::Pkh, true)?;
+//!     let hwi_address = device.display_address_with_path(&derivation_path, types::HWIAddressType::Legacy, types::HWIChain::Test)?;
 //!     println!("{}", hwi_address.address);
 //!     Ok(())
 //! }
@@ -60,7 +63,7 @@ mod tests {
     #[serial]
     fn test_get_master_xpub() {
         let device = get_first_device();
-        device.get_master_xpub(true).unwrap();
+        device.get_master_xpub(types::HWIChain::Test).unwrap();
     }
 
     #[test]
@@ -71,7 +74,9 @@ mod tests {
             ChildNumber::from_hardened_idx(44).unwrap(),
             ChildNumber::from_normal_idx(0).unwrap(),
         ]);
-        device.get_xpub(&derivation_path, true).unwrap();
+        device
+            .get_xpub(&derivation_path, types::HWIChain::Test)
+            .unwrap();
     }
 
     #[test]
@@ -83,7 +88,11 @@ mod tests {
             ChildNumber::from_normal_idx(0).unwrap(),
         ]);
         device
-            .sign_message("I love magical bitcoin wallet", &derivation_path, true)
+            .sign_message(
+                "I love magical bitcoin wallet",
+                &derivation_path,
+                types::HWIChain::Test,
+            )
             .unwrap();
     }
 
@@ -92,7 +101,9 @@ mod tests {
     fn test_get_descriptors() {
         let device = get_first_device();
         let account = Some(10);
-        let descriptor = device.get_descriptors(account, true).unwrap();
+        let descriptor = device
+            .get_descriptors(account, types::HWIChain::Test)
+            .unwrap();
         assert!(descriptor.internal.len() > 0);
         assert!(descriptor.receive.len() > 0);
     }
@@ -101,50 +112,95 @@ mod tests {
     #[serial]
     fn test_display_address_with_desc() {
         let device = get_first_device();
-        let descriptor = device.get_descriptors(None, true).unwrap();
+        let descriptor = device.get_descriptors(None, types::HWIChain::Test).unwrap();
         let descriptor = descriptor.receive.first().unwrap();
         // Seems like hwi doesn't support descriptors checksums
         let descriptor = &descriptor.split("#").collect::<Vec<_>>()[0].to_string();
         let descriptor = &descriptor.replace("*", "1"); // e.g. /0/* -> /0/1
-        device.display_address_with_desc(&descriptor, true).unwrap();
-    }
-
-    #[test]
-    #[serial]
-    fn test_display_address_with_path_pkh() {
-        let device = get_first_device();
-        let derivation_path = DerivationPath::from(vec![
-            ChildNumber::from_hardened_idx(44).unwrap(),
-            ChildNumber::from_normal_idx(0).unwrap(),
-        ]);
         device
-            .display_address_with_path(&derivation_path, types::HWIAddressType::Pkh, true)
+            .display_address_with_desc(&descriptor, types::HWIChain::Test)
             .unwrap();
     }
 
     #[test]
     #[serial]
-    fn test_display_address_with_path_shwpkh() {
+    fn test_display_address_with_path_legacy() {
         let device = get_first_device();
         let derivation_path = DerivationPath::from(vec![
             ChildNumber::from_hardened_idx(44).unwrap(),
+            ChildNumber::from_hardened_idx(1).unwrap(),
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
             ChildNumber::from_normal_idx(0).unwrap(),
         ]);
         device
-            .display_address_with_path(&derivation_path, types::HWIAddressType::ShWpkh, true)
+            .display_address_with_path(
+                &derivation_path,
+                types::HWIAddressType::Legacy,
+                types::HWIChain::Test,
+            )
             .unwrap();
     }
 
     #[test]
     #[serial]
-    fn test_display_address_with_path_wpkh() {
+    fn test_display_address_with_path_nested_segwit() {
         let device = get_first_device();
         let derivation_path = DerivationPath::from(vec![
-            ChildNumber::from_hardened_idx(44).unwrap(),
+            ChildNumber::from_hardened_idx(49).unwrap(),
+            ChildNumber::from_hardened_idx(1).unwrap(),
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
             ChildNumber::from_normal_idx(0).unwrap(),
         ]);
         device
-            .display_address_with_path(&derivation_path, types::HWIAddressType::Wpkh, true)
+            .display_address_with_path(
+                &derivation_path,
+                types::HWIAddressType::Sh_Wit,
+                types::HWIChain::Test,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn test_display_address_with_path_native_segwit() {
+        let device = get_first_device();
+        let derivation_path = DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(84).unwrap(),
+            ChildNumber::from_hardened_idx(1).unwrap(),
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+        ]);
+        device
+            .display_address_with_path(
+                &derivation_path,
+                types::HWIAddressType::Wit,
+                types::HWIChain::Test,
+            )
+            .unwrap();
+    }
+
+    // TODO: Taproot Checksum fails
+    // #[test]
+    // #[serial]
+    #[allow(dead_code)]
+    fn test_display_address_with_path_taproot() {
+        let device = get_first_device();
+        let derivation_path = DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(86).unwrap(),
+            ChildNumber::from_hardened_idx(1).unwrap(),
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+        ]);
+        device
+            .display_address_with_path(
+                &derivation_path,
+                types::HWIAddressType::Tap,
+                types::HWIChain::Test,
+            )
             .unwrap();
     }
 
@@ -160,7 +216,7 @@ mod tests {
         let device = get_first_device();
         let keypool = true;
         let internal = false;
-        let address_type = types::HWIAddressType::Pkh;
+        let address_type = types::HWIAddressType::Legacy;
         let account = Some(8);
         let derivation_path = DerivationPath::from(vec![
             ChildNumber::from_hardened_idx(44).unwrap(),
@@ -177,13 +233,13 @@ mod tests {
                 Some(&derivation_path),
                 start,
                 end,
-                true,
+                types::HWIChain::Test,
             )
             .unwrap();
 
         let keypool = true;
         let internal = true;
-        let address_type = types::HWIAddressType::Wpkh;
+        let address_type = types::HWIAddressType::Wit;
         let account = None;
         let start = 1;
         let end = 8;
@@ -196,13 +252,13 @@ mod tests {
                 None,
                 start,
                 end,
-                true,
+                types::HWIChain::Test,
             )
             .unwrap();
 
         let keypool = false;
         let internal = true;
-        let address_type = types::HWIAddressType::ShWpkh;
+        let address_type = types::HWIAddressType::Sh_Wit;
         let account = Some(1);
         let start = 0;
         let end = 10;
@@ -215,7 +271,7 @@ mod tests {
                 Some(&derivation_path),
                 start,
                 end,
-                true,
+                types::HWIChain::Test,
             )
             .unwrap();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,24 @@ mod tests {
     // TODO: Taproot Checksum fails
     // #[test]
     // #[serial]
-    // fn test_display_address_with_path_taproot() {}
+    #[allow(dead_code)]
+    fn test_display_address_with_path_taproot() {
+        let device = get_first_device();
+        let derivation_path = DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(86).unwrap(),
+            ChildNumber::from_hardened_idx(1).unwrap(),
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+        ]);
+        device
+            .display_address_with_path(
+                &derivation_path,
+                types::HWIAddressType::Tap,
+                types::HWIChain::Test,
+            )
+            .unwrap();
+    }
 
     #[test]
     #[serial]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,24 +187,7 @@ mod tests {
     // TODO: Taproot Checksum fails
     // #[test]
     // #[serial]
-    #[allow(dead_code)]
-    fn test_display_address_with_path_taproot() {
-        let device = get_first_device();
-        let derivation_path = DerivationPath::from(vec![
-            ChildNumber::from_hardened_idx(86).unwrap(),
-            ChildNumber::from_hardened_idx(1).unwrap(),
-            ChildNumber::from_hardened_idx(0).unwrap(),
-            ChildNumber::from_normal_idx(0).unwrap(),
-            ChildNumber::from_normal_idx(0).unwrap(),
-        ]);
-        device
-            .display_address_with_path(
-                &derivation_path,
-                types::HWIAddressType::Tap,
-                types::HWIChain::Test,
-            )
-            .unwrap();
-    }
+    // fn test_display_address_with_path_taproot() {}
 
     #[test]
     #[serial]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,9 @@ mod tests {
     use crate::interface;
     use crate::types;
 
+    use bitcoin::consensus::deserialize;
     use bitcoin::util::bip32::{ChildNumber, DerivationPath};
+    use bitcoin::util::psbt::PartiallySignedTransaction;
 
     #[test]
     #[serial]
@@ -204,11 +206,25 @@ mod tests {
             .unwrap();
     }
 
-    // TODO:
-    // #[test]
-    // #[serial]
-    // fn test_sign_tx() {
-    // }
+    #[test]
+    #[serial]
+    fn test_sign_tx() {
+        let psbt = "cHNidP8BAHEBAAAAAaaVHw3iAcicnNY2+6U4C2KZvT4QUtRJ+8iRrkq2A7bgAQAAA\
+        AD9////AlDDAAAAAAAAFgAUOSUKaW5vVMrnlLAP+9jls1dZ4daPwAAAAAAAABYAFAg3N2d5GUtUe+jnFqf\
+        7Bt1aMhw0AAAAAAABAPUCAAAAAAEBCOSAnP+lWUf2Gg2HTarqvYKuKCJhrlJXswra5Rfz59MAAAAAFxYAF\
+        C93+I91yBEKeWJRg8B+7qIEFu7N/v///wK6bRcAAAAAABYAFMIiSx/RM/t6UXdOu0DhZI6bmux6oIYBAAA\
+        AAAAWABQSK7xZt6Pm5uy3sID9UUccOejeRgJHMEQCIFr5wJgP0yXfa8JepCAFOG0iCqtG1DCIrdbbVRK71\
+        mDgAiBzPEKJBt2mmjrWPeITiOp8Mj0OeU0hWKF11tD+wkIbqgEhAnSghcRbPiugkR+yu6P+qsdmNViVcBc\
+        UNTS/I83FGKsbNfIcAAEBH6CGAQAAAAAAFgAUEiu8Wbej5ubst7CA/VFHHDno3kYiBgP73cCLS8X7O3xYg\
+        hwT6yNmfMj5LxpQHSuwXzMxrLA34hjCWNLkVAAAgAEAAIAAAACAAAAAAAAAAAAAIgIC7kJ5LdbBfp0iOLk\
+        +f5ejCtVzC2P113MSwbiE/PE6PB0YwljS5FQAAIABAACAAAAAgAAAAAAJAAAAACICAntsamY11CucuHHsb\
+        qaW7G2Z3L+a7ZNwanWGcsYEvuqWGMJY0uRUAACAAQAAgAAAAIABAAAAAAAAAAA=";
+        let bytes = base64::decode(psbt).unwrap();
+        let psbt: PartiallySignedTransaction = deserialize(&bytes[..]).unwrap();
+        // println!("{:#?}", psbt.extract_tx());
+        let device = get_first_device();
+        device.sign_tx(&psbt, types::HWIChain::Test).unwrap();
+    }
 
     #[test]
     #[serial]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,9 @@
+use std::ops::Deref;
+
 use bitcoin::util::address::Address;
 use bitcoin::util::bip32::ExtendedPubKey;
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 #[derive(Deserialize)]
 pub struct HWIExtendedPubKey {
@@ -10,7 +12,21 @@ pub struct HWIExtendedPubKey {
 
 #[derive(Deserialize)]
 pub struct HWISignature {
-    pub signature: String,
+    #[serde(deserialize_with="from_b64")]
+    pub signature: Vec<u8>,
+}
+
+fn from_b64<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+    let b64_string = String::deserialize(d)?;
+    base64::decode(&b64_string).map_err(|_| serde::de::Error::custom("Error while Deserializing Signature"))
+}
+
+impl Deref for HWISignature {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.signature
+    }
 }
 
 #[derive(Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,14 +11,6 @@ pub struct HWIExtendedPubKey {
     pub xpub: ExtendedPubKey,
 }
 
-impl Deref for HWIExtendedPubKey {
-    type Target = ExtendedPubKey;
-
-    fn deref(&self) -> &Self::Target {
-        &self.xpub
-    }
-}
-
 #[derive(Deserialize)]
 pub struct HWISignature {
     #[serde(deserialize_with="from_b64")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,6 +11,14 @@ pub struct HWIExtendedPubKey {
     pub xpub: ExtendedPubKey,
 }
 
+impl Deref for HWIExtendedPubKey {
+    type Target = ExtendedPubKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.xpub
+    }
+}
+
 #[derive(Deserialize)]
 pub struct HWISignature {
     #[serde(deserialize_with="from_b64")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,9 +40,19 @@ pub struct HWIKeyPoolElement {
     pub watchonly: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
+#[allow(non_camel_case_types)]
 pub enum HWIAddressType {
-    Pkh,
-    ShWpkh,
-    Wpkh,
+    Legacy,
+    Sh_Wit,
+    Wit,
+    Tap,
+}
+
+#[derive(Debug)]
+pub enum HWIChain {
+    Main,
+    Test,
+    RegTest,
+    SigNet,
 }


### PR DESCRIPTION
Fixes #6,
Updated flags and commands to match the current version of the HWI binary. For example `--testnet` flag to `--chain` arguments etc.
Some tests are changed to better suit the changed address types. Please do verify the tests if they are up to mark. I changed the Derivation Paths to comply with BIP44 which was required by my hardware wallet. 
I have no idea why taproot checksum fails.