### PR TITLE
[GetXpub] Added expert flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ pip install -r requirements.txt
 | --version | Planned |
 | --stdin | NO |
 | --interactive | Planned |
+| --expert | YES |
 
 ## Tests
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -141,6 +141,16 @@ impl HWICommand {
         self
     }
 
+   /// Adds expert flag to a HWICommand
+    /// # Arguments
+    /// * `e` - whether to add "--expert" flag or not.
+    pub fn add_expert(&mut self, e: bool) -> &mut Self {
+        if e {
+            self.command.arg("--expert");
+        }
+        self
+    }
+
     /// Adds a message to a HWICommand
     /// # Arguments
     /// * `message` - the message to add. Note that it's escaped, preventing injections.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -80,14 +80,17 @@ impl HWIDevice {
     /// # Arguments
     /// * `path` - The derivation path to derive the key.
     /// * `chain` - Specify which chain to use.
+    /// * `expert` - Whether to provide more information or not.
     pub fn get_xpub(
         &self,
         path: &DerivationPath,
+        expert: bool,
         chain: HWIChain,
     ) -> Result<HWIExtendedPubKey, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
             .add_chain(chain)
+            .add_expert(expert)
             .add_subcommand(HWISubcommand::GetXpub)
             .add_path(path, false, false)
             .execute()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,21 @@ mod tests {
             ChildNumber::from_normal_idx(0).unwrap(),
         ]);
         device
-            .get_xpub(&derivation_path, types::HWIChain::Test)
+            .get_xpub(&derivation_path, false, types::HWIChain::Test)
+            .unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn test_get_xpub_with_expert_flag_set() {
+        let device = get_first_device();
+        let derivation_path = DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(44).unwrap(),
+            ChildNumber::from_normal_idx(0).unwrap(),
+        ]);
+
+        device
+            .get_xpub(&derivation_path, true, types::HWIChain::Test)
             .unwrap();
     }
 


### PR DESCRIPTION
Added `--expert` flag to GetXpub as per latest standards https://hwi.readthedocs.io/en/latest/usage/api-usage.html#hwilib.commands.getxpub

expert flag when set, provides more information intended for experts.

