### PR TITLE
Set-up a new device functionality

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,7 +15,7 @@ pub enum HWISubcommand {
     GetKeypool,
     GetDescriptors,
     DisplayAddress,
-    // TODO: Setup,
+    Setup,
     // TODO: Wipe,
     // TODO: Restore,
     // TODO: Backup,
@@ -186,6 +186,18 @@ impl HWICommand {
     pub fn add_start_end(&mut self, start: u32, end: u32) -> &mut Self {
         self.command
             .args(vec![format!("{}", start), format!("{}", end)]);
+        self
+    }
+
+    /// Adds a label (and `--label` flag) to a HWICommand
+    pub fn add_label(&mut self, label: &str) -> &mut Self {
+        self.command.args(vec!["--label", label]);
+        self
+    }
+
+    /// Adds a backup_passphrase (and `--backup_passphrase` flag) to a HWICommand
+    pub fn add_backup_passphrase(&mut self, backup_passphrase: &str) -> &mut Self {
+        self.command.args(vec!["--backup_passphrase", backup_passphrase]);
         self
     }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -13,7 +13,7 @@ use crate::commands::{HWICommand, HWIFlag, HWISubcommand};
 use crate::error::Error;
 use crate::types::{
     HWIAddress, HWIAddressType, HWIDescriptor, HWIExtendedPubKey, HWIKeyPoolElement,
-    HWIPartiallySignedTransaction, HWISignature,
+    HWIPartiallySignedTransaction, HWISignature, HWISetup, 
 };
 
 macro_rules! deserialize_obj {
@@ -216,6 +216,27 @@ impl HWIDevice {
             .add_path(&path, true, false)
             .add_address_type(address_type)
             .execute()?;
+        deserialize_obj!(&output.stdout)
+    }
+
+    /// Used to setup a device that has not yet been initialized.
+    /// # Arguments
+    /// * `label` - Label to apply to the newly setup device.
+    /// * `backup_passphrase` - The passphrase to use for the backup, if applicable.
+    /// * `testnet` - Whether to use testnet or not.
+    pub fn setup_device(
+        &self,
+        label: &str,
+        backup_passphrase: &str,
+        testnet: bool,
+    ) -> Result<HWISetup, Error> {
+        let output = HWICommand::new()
+                .add_flag(HWIFlag::Fingerprint(self.fingerprint))
+                .add_testnet(testnet)
+                .add_subcommand(HWISubcommand::Setup)
+                .add_label(&label)
+                .add_backup_passphrase(&backup_passphrase)
+                .execute()?;
         deserialize_obj!(&output.stdout)
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,6 +40,11 @@ pub struct HWIKeyPoolElement {
     pub watchonly: bool,
 }
 
+#[derive(Deserialize)]
+pub struct HWISetup {
+    pub success: bool,
+}
+
 #[derive(Clone)]
 pub enum HWIAddressType {
     Pkh,


### PR DESCRIPTION
Api reference: https://hwi.readthedocs.io/en/latest/usage/api-usage.html#hwilib.commands.setup_device
CLI reference: https://hwi.readthedocs.io/en/latest/usage/cli-usage.html#hwi-setup


Supported Devices:
- Trezor
- Keepkey
- Digital BitBox (Requires both label and backup passphrase)

UnSupported Devices:
- Coldcard
- Ledger Nano S and X