### PR TITLE
Compatibility upgraded to HWI 2.0.2 binary along with fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/MagicalBitcoin/rust-hwi"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = { version = "0.25", features = ["use-serde"] }
+bitcoin = { version = "0.25", features = ["use-serde", "base64"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 strum_macros = "0.18.0"

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -12,7 +12,7 @@ use serde_json::value::Value;
 use crate::commands::{HWICommand, HWIFlag, HWISubcommand};
 use crate::error::Error;
 use crate::types::{
-    HWIAddress, HWIAddressType, HWIDescriptor, HWIExtendedPubKey, HWIKeyPoolElement,
+    HWIAddress, HWIAddressType, HWIChain, HWIDescriptor, HWIExtendedPubKey, HWIKeyPoolElement,
     HWIPartiallySignedTransaction, HWISignature,
 };
 
@@ -48,10 +48,10 @@ impl HWIDevice {
     /// Returns the master xpub of a device.
     /// # Arguments
     /// * `testnet` - Whether to use testnet or not.
-    pub fn get_master_xpub(&self, testnet: bool) -> Result<HWIExtendedPubKey, Error> {
+    pub fn get_master_xpub(&self, chain: HWIChain) -> Result<HWIExtendedPubKey, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::GetMasterXpub)
             .execute()?;
         deserialize_obj!(&output.stdout)
@@ -64,12 +64,12 @@ impl HWIDevice {
     pub fn sign_tx(
         &self,
         psbt: &PartiallySignedTransaction,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWIPartiallySignedTransaction, Error> {
         let psbt = base64::encode(&serialize(psbt));
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::SignTx)
             .add_psbt(&psbt)
             .execute()?;
@@ -83,11 +83,11 @@ impl HWIDevice {
     pub fn get_xpub(
         &self,
         path: &DerivationPath,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWIExtendedPubKey, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::GetXpub)
             .add_path(&path, false, false)
             .execute()?;
@@ -103,11 +103,11 @@ impl HWIDevice {
         &self,
         message: &str,
         path: &DerivationPath,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWISignature, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::SignMessage)
             .add_message(&message)
             .add_path(&path, false, false)
@@ -134,12 +134,12 @@ impl HWIDevice {
         path: Option<&DerivationPath>,
         start: u32,
         end: u32,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<Vec<HWIKeyPoolElement>, Error> {
         let mut command = HWICommand::new();
         command
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::GetKeypool)
             .add_keypool(keypool)
             .add_internal(internal)
@@ -164,12 +164,12 @@ impl HWIDevice {
     pub fn get_descriptors(
         &self,
         account: Option<u32>,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWIDescriptor, Error> {
         let mut command = HWICommand::new();
         command
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::GetDescriptors);
 
         if let Some(a) = account {
@@ -187,11 +187,11 @@ impl HWIDevice {
     pub fn display_address_with_desc(
         &self,
         descriptor: &str,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWIAddress, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::DisplayAddress)
             .add_descriptor(&descriptor)
             .execute()?;
@@ -207,11 +207,11 @@ impl HWIDevice {
         &self,
         path: &DerivationPath,
         address_type: HWIAddressType,
-        testnet: bool,
+        chain: HWIChain,
     ) -> Result<HWIAddress, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
-            .add_testnet(testnet)
+            .add_chain(chain)
             .add_subcommand(HWISubcommand::DisplayAddress)
             .add_path(&path, true, false)
             .add_address_type(address_type)

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use bitcoin::util::address::Address;
+use bitcoin::util::{address::Address, psbt::PartiallySignedTransaction};
 use bitcoin::util::bip32::ExtendedPubKey;
 
 use std::ops::Deref;
@@ -36,7 +36,15 @@ pub struct HWIAddress {
 
 #[derive(Deserialize)]
 pub struct HWIPartiallySignedTransaction {
-    pub psbt: String,
+    pub psbt: PartiallySignedTransaction,
+}
+
+impl Deref for HWIPartiallySignedTransaction {
+    type Target = PartiallySignedTransaction;
+
+    fn deref(&self) -> &Self::Target {
+        &self.psbt
+    }
 }
 
 // TODO: use Descriptors

--- a/src/types.rs
+++ b/src/types.rs
@@ -72,9 +72,19 @@ pub struct HWIKeyPoolElement {
     pub watchonly: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
+#[allow(non_camel_case_types)]
 pub enum HWIAddressType {
-    Pkh,
-    ShWpkh,
-    Wpkh,
+    Legacy,
+    Sh_Wit,
+    Wit,
+    Tap,
+}
+
+#[derive(Debug)]
+pub enum HWIChain {
+    Main,
+    Test,
+    Regtest,
+    Signet,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,8 @@
 use bitcoin::util::address::Address;
 use bitcoin::util::bip32::ExtendedPubKey;
 
-use serde::Deserialize;
+use std::ops::Deref;
+use serde::{Deserialize, Deserializer};
 
 #[derive(Deserialize)]
 pub struct HWIExtendedPubKey {
@@ -10,7 +11,22 @@ pub struct HWIExtendedPubKey {
 
 #[derive(Deserialize)]
 pub struct HWISignature {
-    pub signature: String,
+    #[serde(deserialize_with = "from_b64")]
+    pub signature: Vec<u8>,
+}
+
+fn from_b64<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+    let b64_string = String::deserialize(d)?;
+    base64::decode(&b64_string)
+        .map_err(|_| serde::de::Error::custom("Error while Deserializing Signature"))
+}
+
+impl Deref for HWISignature {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.signature
+    }
 }
 
 #[derive(Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,14 @@ pub struct HWIExtendedPubKey {
     pub xpub: ExtendedPubKey,
 }
 
+impl Deref for HWIExtendedPubKey {
+    type Target = ExtendedPubKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.xpub
+    }
+}
+
 #[derive(Deserialize)]
 pub struct HWISignature {
     #[serde(deserialize_with = "from_b64")]


### PR DESCRIPTION
Updated flags and commands to match the current version of the HWI binary. For example `--testnet` flag to `--chain` arguments etc.