### PR TITLE
Rectify documentation, fix clippy warnings and update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features
+        args: --all-features -- -D warnings
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ repository = "https://github.com/MagicalBitcoin/rust-hwi"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = { version = "0.25", features = ["use-serde", "base64"] }
+bitcoin = { version = "0.28", features = ["use-serde", "base64"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-strum_macros = "0.18.0"
-base64 = "^0.11"
+strum_macros = "0.24.0"
+base64 = "^0.13.0"
 
 [dev-dependencies]
-serial_test = "0.4.0"
+serial_test = "0.6.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,1 @@
-ecdsa==0.13.3
-hidapi==0.7.99.post21
-hwi
-libusb1==1.7.1
-mnemonic==0.18
-pbkdf2==1.3
-pyaes==1.6.1
-typing-extensions==3.7.4.1
+hwi>=2.0.2,<3

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -42,10 +42,10 @@ impl HWIFlag {
     /// Returns a vector of args from a flag
     fn to_args_vec(&self) -> Vec<String> {
         match self {
-            HWIFlag::DevicePath(p) => vec![String::from("--device-path"), format!("{}", p)],
-            HWIFlag::DeviceType(t) => vec![String::from("--device-type"), format!("{}", t)],
-            HWIFlag::Password(p) => vec![String::from("--password"), format!("{}", p)],
-            HWIFlag::Fingerprint(f) => vec![String::from("--fingerprint"), format!("{}", f)],
+            HWIFlag::DevicePath(p) => vec![String::from("--device-path"), p.to_string()],
+            HWIFlag::DeviceType(t) => vec![String::from("--device-type"), t.to_string()],
+            HWIFlag::Password(p) => vec![String::from("--password"), p.to_string()],
+            HWIFlag::Fingerprint(f) => vec![String::from("--fingerprint"), f.to_string()],
             HWIFlag::Chain(chain) => vec![
                 String::from("--chain"),
                 format!("{:?}", chain).to_lowercase(),
@@ -61,6 +61,12 @@ impl HWIFlag {
 #[derive(Debug)]
 pub struct HWICommand {
     command: Command,
+}
+
+impl Default for HWICommand {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl HWICommand {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -47,7 +47,7 @@ impl HWIDevice {
 
     /// Returns the master xpub of a device.
     /// # Arguments
-    /// * `testnet` - Whether to use testnet or not.
+    /// * `chain` - Specify which chain to use.
     pub fn get_master_xpub(&self, chain: HWIChain) -> Result<HWIExtendedPubKey, Error> {
         let output = HWICommand::new()
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
@@ -60,7 +60,7 @@ impl HWIDevice {
     /// Returns a psbt signed.
     /// # Arguments
     /// * `psbt` - The PSBT to be signed.
-    /// * `testnet` - Whether to use testnet or not.
+    /// * `chain` - Specify which chain to use.
     pub fn sign_tx(
         &self,
         psbt: &PartiallySignedTransaction,
@@ -79,7 +79,7 @@ impl HWIDevice {
     /// Returns the xpub of a device.
     /// # Arguments
     /// * `path` - The derivation path to derive the key.
-    /// * `testnet` - Whether to use testnet or not.
+    /// * `chain` - Specify which chain to use.
     pub fn get_xpub(
         &self,
         path: &DerivationPath,
@@ -98,7 +98,7 @@ impl HWIDevice {
     /// # Arguments
     /// * `message` - The message to sign.
     /// * `path` - The derivation path to derive the key.
-    /// * `testnet` - Whether to use testnet or not.
+    /// * `chain` - Specify which chain to use.
     pub fn sign_message(
         &self,
         message: &str,
@@ -124,7 +124,7 @@ impl HWIDevice {
     /// * `path` - The derivation path to derive the keys.
     /// * `start` - Keypool start
     /// * `end` - Keypool end
-    /// * `testnet` - Whether to use testnet or not.
+    /// * `chain` - Specify which chain to use.
     #[allow(clippy::too_many_arguments)]
     pub fn get_keypool(
         &self,
@@ -161,7 +161,7 @@ impl HWIDevice {
     /// Returns device descriptors
     /// # Arguments
     /// * `account` - Optional BIP43 account to use.
-    /// * `testnet` - Whether to use testnet or not.
+    /// * `chain` - Specify which chain to use.
     pub fn get_descriptors(
         &self,
         account: Option<u32>,
@@ -184,7 +184,7 @@ impl HWIDevice {
     /// Returns an address given a descriptor.
     /// # Arguments
     /// * `descriptor` - The descriptor to use. HWI doesn't support descriptors checksums.
-    /// * `testnet` - Whether to use testnet or not.
+    /// * `chain` - Specify which chain to use.
     pub fn display_address_with_desc(
         &self,
         descriptor: &str,
@@ -203,7 +203,7 @@ impl HWIDevice {
     /// # Arguments
     /// * `path` - The derivation path to use.
     /// * `address_type` - Address type to use.
-    /// * `testnet` - Whether to use testnet or not.
+    /// * `chain` - Specify which chain to use.
     pub fn display_address_with_path(
         &self,
         path: &DerivationPath,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -89,7 +89,7 @@ impl HWIDevice {
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
             .add_chain(chain)
             .add_subcommand(HWISubcommand::GetXpub)
-            .add_path(&path, false, false)
+            .add_path(path, false, false)
             .execute()?;
         deserialize_obj!(&output.stdout)
     }
@@ -109,8 +109,8 @@ impl HWIDevice {
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
             .add_chain(chain)
             .add_subcommand(HWISubcommand::SignMessage)
-            .add_message(&message)
-            .add_path(&path, false, false)
+            .add_message(message)
+            .add_path(path, false, false)
             .execute()?;
         deserialize_obj!(&output.stdout)
     }
@@ -125,6 +125,7 @@ impl HWIDevice {
     /// * `start` - Keypool start
     /// * `end` - Keypool end
     /// * `testnet` - Whether to use testnet or not.
+    #[allow(clippy::too_many_arguments)]
     pub fn get_keypool(
         &self,
         keypool: bool,
@@ -150,7 +151,7 @@ impl HWIDevice {
         }
 
         if let Some(p) = path {
-            command.add_path(&p, true, true);
+            command.add_path(p, true, true);
         }
 
         let output = command.add_start_end(start, end).execute()?;
@@ -193,7 +194,7 @@ impl HWIDevice {
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
             .add_chain(chain)
             .add_subcommand(HWISubcommand::DisplayAddress)
-            .add_descriptor(&descriptor)
+            .add_descriptor(descriptor)
             .execute()?;
         deserialize_obj!(&output.stdout)
     }
@@ -213,7 +214,7 @@ impl HWIDevice {
             .add_flag(HWIFlag::Fingerprint(self.fingerprint))
             .add_chain(chain)
             .add_subcommand(HWISubcommand::DisplayAddress)
-            .add_path(&path, true, false)
+            .add_path(path, true, false)
             .add_address_type(address_type)
             .execute()?;
         deserialize_obj!(&output.stdout)


### PR DESCRIPTION
Documentation for some functions still contained the `testnet` argument. I changed them to the `chain` argument.
Clippy warnings were corrected, where possible. Otherwise, I suppressed them (at 1 place in total).
Dependencies were updated to the latest versions compatible with each other.