### PR TITLE
Make HWILib private

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -26,7 +26,7 @@ macro_rules! deserialize_obj {
 }
 
 /// Convenience class containing required Python objects
-pub struct HWILib {
+struct HWILib {
     commands: Py<PyModule>,
     json_dumps: Py<PyAny>,
 }
@@ -45,8 +45,8 @@ impl HWILib {
 }
 
 pub struct HWIClient {
-    pub hwilib: HWILib,
-    pub hw_client: PyObject,
+    hwilib: HWILib,
+    hw_client: PyObject,
 }
 
 impl Deref for HWIClient {


### PR DESCRIPTION
It's not meant to be used by end users, so let's keep it private