### PR TITLE
Add build script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 hwi>=2.1.1,<3
 protobuf==3.20.1
+requests>=2.27.1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,11 @@ mod tests {
             break;
         }
     }
+    #[test]
+    #[serial]
+    fn test_get_version() {
+        HWIClient::get_version().unwrap();
+    }
 
     #[test]
     #[serial]
@@ -321,5 +326,11 @@ mod tests {
             let client = HWIClient::get_client(&device, true, types::HWIChain::Test).unwrap();
             client.wipe_device().unwrap();
         }
+    }
+    #[test]
+    #[serial]
+    #[ignore]
+    fn test_install_hwi() {
+        HWIClient::install_hwilib(Some("2.1.1")).unwrap();
     }
 }


### PR DESCRIPTION
I believe this should be all that is needed. I don't think we can install OS-level dependencies. For udev rules, it is possible but then we would have to duplicate/include_str the `install_udev_rules()` function in `build.rs`