### PR TITLE
ci: Run README examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,3 +55,36 @@ jobs:
       run: cargo test
     - name: Wipe
       run: cargo test test_wipe_device -- --ignored
+  test-readme-examples:
+    name: Test README.md examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-md-docs-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Build simulator image
+        run: docker build -t hwi/ledger_emulator ./ci -f ci/Dockerfile.ledger
+      - name: Run simulator image
+        run: docker run --name simulator --network=host hwi/ledger_emulator &
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - name: Install python dependencies
+        run: pip install -r requirements.txt
+      - name: Set default toolchain
+        run: rustup default nightly
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Update toolchain
+        run: rustup update
+      - name: Test
+        run: cargo test --features doctest -- doctest::ReadmeDoctests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ pyo3 = { version = "0.15.1", features = ["auto-initialize"]}
 
 [dev-dependencies]
 serial_test = "0.6.0"
+
+[features]
+doctest = []

--- a/README.md
+++ b/README.md
@@ -13,37 +13,37 @@ This library internally uses PyO3 to call HWI's functions. It is not a re-implem
 Python 3 is required. The libraries and [udev rules](https://github.com/bitcoin-core/HWI/blob/master/hwilib/udev/README.md) for each device must also be installed. Some libraries will need to be installed
 
 For Ubuntu/Debian:
-```
+```bash
 sudo apt install libusb-1.0-0-dev libudev-dev python3-dev
 ```
 
 For Centos:
-```
+```bash
 sudo yum -y install python3-devel libusbx-devel systemd-devel
 ```
 
 For macOS:
-```
+```bash
 brew install libusb
 ```
 
 ## Install
 
 - Clone the repo
-```
+```bash
 git clone https://github.com/bitcoindevkit/rust-hwi.git && cd rust-hwi
 ```
 
 - Create a virtualenv:
 
-```
+```bash
 virtualenv -p python3 venv
 source venv/bin/activate
 ```
 
 - Install all the dependencies using pip:
 
-```
+```bash
 pip install -r requirements.txt
 ```
 

--- a/src/doctest.rs
+++ b/src/doctest.rs
@@ -1,0 +1,14 @@
+// Bitcoin Dev Kit
+// Written in 2020 by Alekos Filini <alekos.filini@gmail.com>
+//
+// Copyright (c) 2020-2021 Bitcoin Dev Kit Developers
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+#[doc = include_str!("../README.md")]
+#[cfg(doctest)]
+pub struct ReadmeDoctests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ extern crate serial_test;
 
 pub use interface::HWIClient;
 
+#[cfg(feature = "doctest")]
+pub mod doctest;
 pub mod error;
 pub mod interface;
 pub mod types;


### PR DESCRIPTION
Adds a "doctest" feature useful if you want to run the README.md tests.
Largely copied from bdk's CI workflow.