### PR TITLE
Add a new Signer for BDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
           rust:
             - version: 1.61.0 # STABLE
-            - version: 1.41.1 # MSRV
+            - version: 1.56.1 # MSRV
           emulator:
             - name: trezor
             - name: ledger

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ bitcoin = { version = "0.28", features = ["use-serde", "base64"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 pyo3 = { version = "0.15.1", features = ["auto-initialize"]}
+bdk = "0.20.0"
 
 [dev-dependencies]
 serial_test = "0.6.0"

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -26,6 +26,7 @@ macro_rules! deserialize_obj {
 }
 
 /// Convenience class containing required Python objects
+#[derive(Debug)]
 struct HWILib {
     commands: Py<PyModule>,
     json_dumps: Py<PyAny>,
@@ -44,6 +45,7 @@ impl HWILib {
     }
 }
 
+#[derive(Debug)]
 pub struct HWIClient {
     hwilib: HWILib,
     hw_client: PyObject,

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -1,0 +1,51 @@
+use bdk::signer::{SignerCommon, SignerError, SignerId, TransactionSigner};
+use bitcoin::{
+    psbt::PartiallySignedTransaction,
+    secp256k1::{All, Secp256k1},
+    util::bip32::Fingerprint,
+};
+
+use crate::{
+    error::Error,
+    types::{HWIChain, HWIDevice},
+    HWIClient,
+};
+
+#[derive(Debug)]
+pub struct HWISigner {
+    fingerprint: Fingerprint,
+    client: HWIClient,
+}
+
+impl HWISigner {
+    pub fn from_device(device: &HWIDevice, chain: HWIChain) -> Result<HWISigner, Error> {
+        let client = HWIClient::get_client(device, false, chain)?;
+        Ok(HWISigner {
+            fingerprint: device.fingerprint,
+            client,
+        })
+    }
+}
+
+impl SignerCommon for HWISigner {
+    fn id(&self, _secp: &Secp256k1<All>) -> SignerId {
+        SignerId::Fingerprint(self.fingerprint)
+    }
+}
+
+impl TransactionSigner for HWISigner {
+    fn sign_transaction(
+        &self,
+        psbt: &mut PartiallySignedTransaction,
+        _secp: &Secp256k1<All>,
+    ) -> Result<(), SignerError> {
+        psbt.combine(
+            self.client
+                .sign_tx(psbt)
+                .expect("Hardware Wallet couldn't sign transaction")
+                .psbt,
+        )
+        .expect("Failed to combine HW signed psbt with passed PSBT");
+        Ok(())
+    }
+}


### PR DESCRIPTION
The test for the Signer is mostly the BDK example (with small changes) available on the [bdk doc homepage](https://docs.rs/bdk/0.20.0/bdk/).