### PR TITLE
Add PartialEq, Eq, Clone traits to `Error`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Error {
-    JSON(serde_json::error::Error),
-    Utf8(std::str::Utf8Error),
-    IOError(std::io::Error),
+    JSON(String),
+    Utf8(String),
+    IOError(String),
     InvalidOption(String),
     HWIError(String),
     PyErr(String),
@@ -12,7 +12,7 @@ macro_rules! impl_error {
     ( $from:ty, $to:ident ) => {
         impl std::convert::From<$from> for Error {
             fn from(err: $from) -> Self {
-                Error::$to(err)
+                Error::$to(err.to_string())
             }
         }
     };
@@ -21,9 +21,4 @@ macro_rules! impl_error {
 impl_error!(serde_json::Error, JSON);
 impl_error!(std::str::Utf8Error, Utf8);
 impl_error!(std::io::Error, IOError);
-
-impl std::convert::From<pyo3::prelude::PyErr> for Error {
-    fn from(err: pyo3::prelude::PyErr) -> Self {
-        Error::PyErr(err.to_string())
-    }
-}
+impl_error!(pyo3::prelude::PyErr, PyErr);


### PR DESCRIPTION
The `Error` enum variants now only contain Strings