### PR TITLE
Use Descriptor instead of &str

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Update toolchain
       run: rustup update
     - name: Test
-      run: cargo test
+      run: cargo test --features use-miniscript
     - name: Wipe
       run: cargo test test_wipe_device -- --ignored
   test-readme-examples:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ readme = "README.md"
 
 [dependencies]
 bitcoin = { version = "0.29.1", features = ["serde", "base64"] }
+miniscript = { version = "8.0", features = ["serde"], optional = true }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-pyo3 = { version = "0.15.1", features = ["auto-initialize"]}
+pyo3 = { version = "0.15.1", features = ["auto-initialize"] }
 base64 = "0.13.0"
 once_cell = "=1.14"
 
@@ -23,3 +24,4 @@ serial_test = "0.6.0"
 
 [features]
 doctest = []
+use-miniscript = ["miniscript"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,9 @@ mod tests {
     use bitcoin::{secp256k1, Transaction};
     use bitcoin::{TxIn, TxOut};
 
+    #[cfg(feature = "use-miniscript")]
+    use miniscript::{Descriptor, DescriptorPublicKey};
+
     #[test]
     #[serial]
     fn test_enumerate() {
@@ -105,24 +108,46 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_get_descriptors() {
+    fn test_get_string_descriptors() {
         let client = get_first_device();
         let account = Some(10);
-        let descriptor = client.get_descriptors(account).unwrap();
+        let descriptor = client.get_descriptors::<String>(account).unwrap();
         assert!(descriptor.internal.len() > 0);
         assert!(descriptor.receive.len() > 0);
     }
 
     #[test]
     #[serial]
-    fn test_display_address_with_desc() {
+    fn test_display_address_with_string_desc() {
         let client = get_first_device();
-        let descriptor = client.get_descriptors(None).unwrap();
+        let descriptor = client.get_descriptors::<String>(None).unwrap();
         let descriptor = descriptor.receive.first().unwrap();
-        // Seems like hwi doesn't support descriptors checksums
-        let descriptor = &descriptor.split("#").collect::<Vec<_>>()[0].to_string();
-        let descriptor = &descriptor.replace("*", "1"); // e.g. /0/* -> /0/1
-        client.display_address_with_desc(&descriptor).unwrap();
+        client.display_address_with_desc(descriptor).unwrap();
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(feature = "use-miniscript")]
+    fn test_get_miniscript_descriptors() {
+        let client = get_first_device();
+        let account = Some(10);
+        let descriptor = client
+            .get_descriptors::<Descriptor<DescriptorPublicKey>>(account)
+            .unwrap();
+        assert!(descriptor.internal.len() > 0);
+        assert!(descriptor.receive.len() > 0);
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(feature = "use-miniscript")]
+    fn test_display_address_with_miniscript_desc() {
+        let client = get_first_device();
+        let descriptor = client
+            .get_descriptors::<Descriptor<DescriptorPublicKey>>(None)
+            .unwrap();
+        let descriptor = descriptor.receive.first().unwrap();
+        client.display_address_with_desc(descriptor).unwrap();
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,9 @@ use pyo3::types::PyModule;
 use pyo3::{IntoPy, PyObject};
 use serde::{Deserialize, Deserializer};
 
+#[cfg(feature = "use-miniscript")]
+use miniscript::{Descriptor, DescriptorPublicKey};
+
 use crate::error::{Error, ErrorCode};
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize)]
@@ -72,11 +75,18 @@ impl Deref for HWIPartiallySignedTransaction {
     }
 }
 
-// TODO: use Descriptors
+pub trait ToDescriptor {}
+impl ToDescriptor for String {}
+#[cfg(feature = "use-miniscript")]
+impl ToDescriptor for Descriptor<DescriptorPublicKey> {}
+
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize)]
-pub struct HWIDescriptor {
-    pub internal: Vec<String>,
-    pub receive: Vec<String>,
+pub struct HWIDescriptor<T>
+where
+    T: ToDescriptor,
+{
+    pub internal: Vec<T>,
+    pub receive: Vec<T>,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize)]


### PR DESCRIPTION
Resolve bitcoindevkit/rust-hwi#33: use Descriptor instead of &str around the code.