### PR TITLE
ci: downgrade ubuntu to 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all-features -- -D warnings
   test_emulators:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
           rust:
@@ -57,7 +57,7 @@ jobs:
       run: cargo test test_wipe_device -- --ignored
   test-readme-examples:
     name: Test README.md examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Downgrade Ubuntu from 22.04 to 20.04 due a problem with `ripemd160`.
Seems that OpenSSL disabled some older crypto algos (like ripemd160) around v3.0 and ubuntu-latest (22.04) use OpenSSL v3.0.2.
I not found the library that use `ripemd160` (maybe Ledger because with Trezor everything works) so, for now, the downgrade can be the fastest and easier solution to continue to use the CI without incurring the error: "unsupported hash type ripemd160".