### PR TITLE
Update rust-miniscript to 9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 bitcoin = { version = "0.29.1", features = ["serde", "base64"] }
-miniscript = { version = "8.0", features = ["serde"], optional = true }
+miniscript = { version = "9.0", features = ["serde"], optional = true }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 pyo3 = { version = "0.15.1", features = ["auto-initialize"] }


### PR DESCRIPTION
### Description

A new [`rust-miniscript` release 9.0](https://github.com/rust-bitcoin/rust-miniscript/blob/master/CHANGELOG.md#900---november-5-2022) came out on Nov 14.  We should update to stay up-to-date and pickup the bug fixes.

### Notes to the reviewers

This new version of `rust-miniscript` uses the same version of `rust-bitcoin` we are on, 0.29.1.

### Changelog notice

Update rust-miniscript dependency to latest bug fix release 9.0.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing