### PR TITLE
Add msrv1411 feature to pin once_cell to version =1.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,9 @@ jobs:
       matrix:
         rust:
           - version: 1.66.1 # STABLE
+            features: use-miniscript
           - version: 1.41.1 # MSRV
+            features: use-miniscript,msrv1411
         emulator:
           - name: trezor
           - name: ledger
@@ -83,7 +85,7 @@ jobs:
       - name: Update toolchain
         run: rustup update
       - name: Test
-        run: cargo test --features use-miniscript
+        run: cargo test --features ${{ matrix.rust.features }}
       - name: Wipe
         run: cargo test test_wipe_device -- --ignored
   test-readme-examples:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 pyo3 = { version = "0.15.1", features = ["auto-initialize"] }
 base64 = "0.13.0"
-once_cell = "=1.14"
+once_cell = { version = "=1.14", optional = true }
 
 [dev-dependencies]
 serial_test = "0.6.0"
@@ -25,3 +25,4 @@ serial_test = "0.6.0"
 [features]
 doctest = []
 use-miniscript = ["miniscript"]
+msrv1411 = ["once_cell"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Rust wrapper for the [Bitcoin Hardware Wallet Interface](https://github.com/bitc
 
 This library internally uses PyO3 to call HWI's functions. It is not a re-implementation of HWI in native Rust.
 
+## MSRV
+
+The MSRV for this project is `1.41.1` but to support this version you must enable the `msrv1411` feature:
+```cargo
+    [dependencies]
+    hwi = { path = "../rust-hwi", features = ["msrv1411"] }
+```
+If the `msrv1411` feature is not enabled you must use at least rust version `1.56.0`.
+
 ## Prerequisites
 
 Python 3 is required. The libraries and [udev rules](https://github.com/bitcoin-core/HWI/blob/master/hwilib/udev/README.md) for each device must also be installed. Some libraries will need to be installed


### PR DESCRIPTION
This is a bit of a hack, but if we make the pinned version of once_cell an optional feature, then only downstream projects that need the older version can opt-in to it by enabling the "msrv1411" feature. For example if I do this:

```toml
[dependencies]
hwi = { path = "../rust-hwi", features = ["msrv1411"] }
```
Then `cargo update` will set the Cargo.lock version of `once_cell` to 1.14.0.  But if I don't include the feature:
```toml
[dependencies]
hwi = { path = "../rust-hwi" }
```
Then when I do `cargo update` the Cargo.lock version of `once_cell` is changed to 1.17.1.

I'm not in love with the feature name `msrv1411` if you like this approach and have any better ideas.