### PR TITLE
Error overhaul

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -59,7 +59,7 @@ impl TryFrom<i8> for ErrorCode {
             -16 => NeedToBeRoot,
             -17 => HelpText,
             -18 => DeviceNotInitialized,
-            _ => return Err(Error::HWIError("Invalid error code".to_string(), None)),
+            _ => return Err(Error::HWIError("invalid error code".to_string(), None)),
         };
         Ok(code)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,28 +36,32 @@ impl ErrorCode {
 
 impl TryFrom<i8> for ErrorCode {
     type Error = Error;
+
     fn try_from(code: i8) -> Result<Self, Error> {
-        match code {
-            -1 => Ok(Self::NoDeviceType),
-            -2 => Ok(Self::MissingArguments),
-            -3 => Ok(Self::DeviceConnError),
-            -4 => Ok(Self::UnknownDeviceType),
-            -5 => Ok(Self::InvalidTx),
-            -6 => Ok(Self::NoPassword),
-            -7 => Ok(Self::BadArgument),
-            -8 => Ok(Self::NotImplemented),
-            -9 => Ok(Self::UnavailableAction),
-            -10 => Ok(Self::DeviceAlreadyInit),
-            -11 => Ok(Self::DeviceAlreadyUnlocked),
-            -12 => Ok(Self::DeviceNotReady),
-            -13 => Ok(Self::UnknownError),
-            -14 => Ok(Self::ActionCanceled),
-            -15 => Ok(Self::DeviceBusy),
-            -16 => Ok(Self::NeedToBeRoot),
-            -17 => Ok(Self::HelpText),
-            -18 => Ok(Self::DeviceNotInitialized),
-            _ => Err(Error::HWIError("Invalid error code".to_string(), None)),
-        }
+        use ErrorCode::*;
+
+        let code = match code {
+            -1 => NoDeviceType,
+            -2 => MissingArguments,
+            -3 => DeviceConnError,
+            -4 => UnknownDeviceType,
+            -5 => InvalidTx,
+            -6 => NoPassword,
+            -7 => BadArgument,
+            -8 => NotImplemented,
+            -9 => UnavailableAction,
+            -10 => DeviceAlreadyInit,
+            -11 => DeviceAlreadyUnlocked,
+            -12 => DeviceNotReady,
+            -13 => UnknownError,
+            -14 => ActionCanceled,
+            -15 => DeviceBusy,
+            -16 => NeedToBeRoot,
+            -17 => HelpText,
+            -18 => DeviceNotInitialized,
+            _ => return Err(Error::HWIError("Invalid error code".to_string(), None)),
+        };
+        Ok(code)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,7 +59,7 @@ impl TryFrom<i8> for ErrorCode {
             -16 => NeedToBeRoot,
             -17 => HelpText,
             -18 => DeviceNotInitialized,
-            _ => return Err(Error::HWIError("invalid error code".to_string(), None)),
+            _ => return Err(Error::Hwi("invalid error code".to_string(), None)),
         };
         Ok(code)
     }
@@ -73,12 +73,12 @@ impl fmt::Debug for ErrorCode {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Error {
-    JSON(String),
+    Json(String),
     Utf8(String),
-    IOError(String),
+    Io(String),
     InvalidOption(String),
-    HWIError(String, Option<ErrorCode>),
-    PyErr(String),
+    Hwi(String, Option<ErrorCode>),
+    Python(String),
 }
 
 macro_rules! impl_error {
@@ -91,10 +91,10 @@ macro_rules! impl_error {
     };
 }
 
-impl_error!(serde_json::Error, JSON);
+impl_error!(serde_json::Error, Json);
 impl_error!(std::str::Utf8Error, Utf8);
-impl_error!(std::io::Error, IOError);
-impl_error!(pyo3::prelude::PyErr, PyErr);
+impl_error!(std::io::Error, Io);
+impl_error!(pyo3::prelude::PyErr, Python);
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -25,7 +25,7 @@ macro_rules! deserialize_obj {
         let value: Value = serde_json::from_str($e)?;
         let obj = value.clone();
         serde_json::from_value(value)
-            .map_err(|e| Error::HWIError(format!("error {} while deserializing {}", e, obj), None))
+            .map_err(|e| Error::Hwi(format!("error {} while deserializing {}", e, obj), None))
     }};
 }
 
@@ -182,7 +182,7 @@ impl HWIClient {
                 .call1(py, client_args)?;
 
             if client.is_none(py) {
-                return Err(Error::HWIError("device not found".to_string(), None));
+                return Err(Error::Hwi("device not found".to_string(), None));
             }
 
             Ok(HWIClient {
@@ -527,7 +527,7 @@ impl HWIClient {
         if output.status.success() {
             Ok(())
         } else {
-            Err(Error::HWIError(
+            Err(Error::Hwi(
                 std::str::from_utf8(&output.stderr)
                     .expect("Non UTF-8 error while installing")
                     .to_string(),

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -25,7 +25,7 @@ macro_rules! deserialize_obj {
         let value: Value = serde_json::from_str($e)?;
         let obj = value.clone();
         serde_json::from_value(value)
-            .map_err(|e| Error::HWIError(format!("Error {} while deserializing {}", e, obj), None))
+            .map_err(|e| Error::HWIError(format!("error {} while deserializing {}", e, obj), None))
     }};
 }
 
@@ -182,7 +182,7 @@ impl HWIClient {
                 .call1(py, client_args)?;
 
             if client.is_none(py) {
-                return Err(Error::HWIError("Device not found".to_string(), None));
+                return Err(Error::HWIError("device not found".to_string(), None));
             }
 
             Ok(HWIClient {

--- a/src/types.rs
+++ b/src/types.rs
@@ -190,7 +190,7 @@ impl TryFrom<HWIDeviceInternal> for HWIDevice {
         match h.error {
             Some(e) => {
                 let code = h.code.and_then(|c| ErrorCode::try_from(c).ok());
-                Err(Error::HWIError(e, code))
+                Err(Error::Hwi(e, code))
             }
             // When HWIDeviceInternal contains errors, some fields might be missing
             // (depending on the error, hwi might not be able to know all of them).
@@ -222,7 +222,7 @@ impl From<HWIStatus> for Result<(), Error> {
         if s.success {
             Ok(())
         } else {
-            Err(Error::HWIError(
+            Err(Error::Hwi(
                 "request returned with failure".to_string(),
                 None,
             ))

--- a/src/types.rs
+++ b/src/types.rs
@@ -36,7 +36,7 @@ pub struct HWISignature {
 fn from_b64<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
     let b64_string = String::deserialize(d)?;
     base64::decode(b64_string)
-        .map_err(|_| serde::de::Error::custom("Error while Deserializing Signature"))
+        .map_err(|_| serde::de::Error::custom("error while deserializing signature"))
 }
 
 impl Deref for HWISignature {
@@ -223,7 +223,7 @@ impl From<HWIStatus> for Result<(), Error> {
             Ok(())
         } else {
             Err(Error::HWIError(
-                "Request returned with failure".to_string(),
+                "request returned with failure".to_string(),
                 None,
             ))
         }


### PR DESCRIPTION
Overhaul the crate error type including re-naming variants and embedding errors instead of converting to strings.

There is still some improvements that can be done, it looks like the `Error::Hwi` variant is being abused for multiple things. I can't work out right now how to resolve it, if this gets a concept ack I'll either think harder or write up an issue.

Please note this is an API breaking change.