### PR TITLE
Use `bitcoin::Network`

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -101,7 +101,7 @@ impl HWIClient {
     /// let devices = HWIClient::enumerate()?;
     /// for device in devices {
     ///     let device = device?;
-    ///     let client = HWIClient::get_client(&device, false, HWIChain::Test)?;
+    ///     let client = HWIClient::get_client(&device, false, bitcoin::Network::Testnet)?;
     ///     let xpub = client.get_master_xpub(HWIAddressType::Tap, 0)?;
     ///     println!(
     ///         "I can see a {} here, and its xpub is {}",
@@ -150,23 +150,20 @@ impl HWIClient {
     ///     Some(HWIDeviceType::Trezor),
     ///     None,
     ///     false,
-    ///     HWIChain::Test,
+    ///     bitcoin::Network::Testnet,
     /// )?;
     /// let xpub = client.get_master_xpub(HWIAddressType::Tap, 0)?;
     /// println!("Trezor's xpub is {}", xpub.to_string());
     /// # Ok(())
     /// # }
     /// ```
-    pub fn find_device<C>(
+    pub fn find_device(
         password: Option<&str>,
         device_type: Option<HWIDeviceType>,
         fingerprint: Option<&str>,
         expert: bool,
-        chain: C,
-    ) -> Result<HWIClient, Error>
-    where
-        C: Into<HWIChain>,
-    {
+        chain: bitcoin::Network,
+    ) -> Result<HWIClient, Error> {
         let libs = HWILib::initialize()?;
         Python::with_gil(|py| {
             let client_args = (
@@ -174,7 +171,7 @@ impl HWIClient {
                 device_type.map_or_else(String::new, |d| d.to_string()),
                 fingerprint.unwrap_or(""),
                 expert,
-                chain.into(),
+                HWIChain::from(chain),
             );
             let client = libs
                 .commands

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!     }
 //!     let device = devices.remove(0)?;
 //!     // Create a client for a device
-//!     let client = HWIClient::get_client(&device, true, types::HWIChain::Test)?;
+//!     let client = HWIClient::get_client(&device, true, bitcoin::Network::Testnet)?;
 //!     // Display the address from path
 //!     let derivation_path = DerivationPath::from_str("m/44'/1'/0'/0/0").unwrap();
 //!     let hwi_address =
@@ -40,7 +40,7 @@ pub mod types;
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{self, HWIChain, HWIDeviceType};
+    use crate::types::{self, HWIDeviceType};
     use crate::HWIClient;
     use std::collections::BTreeMap;
     use std::str::FromStr;
@@ -48,7 +48,7 @@ mod tests {
     use bitcoin::psbt::{Input, Output};
     use bitcoin::util::bip32::{DerivationPath, KeySource};
     use bitcoin::{secp256k1, Transaction};
-    use bitcoin::{TxIn, TxOut};
+    use bitcoin::{Network, TxIn, TxOut};
 
     #[cfg(feature = "use-miniscript")]
     use miniscript::{Descriptor, DescriptorPublicKey};
@@ -69,7 +69,7 @@ mod tests {
             Some(HWIDeviceType::Trezor),
             None,
             false,
-            types::HWIChain::Test,
+            Network::Testnet,
         )
         .unwrap();
     }
@@ -81,7 +81,7 @@ mod tests {
             .expect("No devices found. Either plug in a hardware wallet, or start a simulator.")
             .as_ref()
             .expect("Error when opening the first device");
-        HWIClient::get_client(&device, true, types::HWIChain::Test).unwrap()
+        HWIClient::get_client(&device, true, Network::Testnet).unwrap()
     }
 
     #[test]
@@ -197,7 +197,7 @@ mod tests {
     fn test_sign_tx() {
         let devices = HWIClient::enumerate().unwrap();
         let device = devices.first().unwrap().as_ref().unwrap();
-        let client = HWIClient::get_client(&device, true, types::HWIChain::Test).unwrap();
+        let client = HWIClient::get_client(&device, true, Network::Testnet).unwrap();
         let derivation_path = DerivationPath::from_str("m/44'/1'/0'/0/0").unwrap();
 
         let address = client
@@ -348,7 +348,7 @@ mod tests {
                 // These devices don't support togglepassphrase
                 continue;
             }
-            let client = HWIClient::get_client(&device, true, types::HWIChain::Test).unwrap();
+            let client = HWIClient::get_client(&device, true, Network::Testnet).unwrap();
             client.toggle_passphrase().unwrap();
             break;
         }
@@ -370,7 +370,7 @@ mod tests {
             Some(HWIDeviceType::Trezor),
             None,
             false,
-            types::HWIChain::Test,
+            Network::Testnet,
         )
         .unwrap();
         client.setup_device(Some("My Label"), None).unwrap();
@@ -386,7 +386,7 @@ mod tests {
             Some(HWIDeviceType::Trezor),
             None,
             false,
-            types::HWIChain::Test,
+            Network::Testnet,
         )
         .unwrap();
         client.restore_device(Some("My Label"), None).unwrap();
@@ -404,7 +404,7 @@ mod tests {
         for device in devices {
             let device = device.unwrap();
             if supported.contains(&device.device_type) {
-                let client = HWIClient::get_client(&device, true, HWIChain::Test).unwrap();
+                let client = HWIClient::get_client(&device, true, Network::Testnet).unwrap();
                 client.backup_device(Some("My Label"), None).unwrap();
             }
         }
@@ -426,7 +426,7 @@ mod tests {
                 // These devices don't support wipe
                 continue;
             }
-            let client = HWIClient::get_client(&device, true, types::HWIChain::Test).unwrap();
+            let client = HWIClient::get_client(&device, true, Network::Testnet).unwrap();
             client.wipe_device().unwrap();
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -124,36 +124,28 @@ impl IntoPy<PyObject> for HWIAddressType {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize)]
-pub enum HWIChain {
-    Main,
-    Test,
-    Regtest,
-    Signet,
-}
+pub struct HWIChain(bitcoin::Network);
 
 impl IntoPy<PyObject> for HWIChain {
     fn into_py(self, py: pyo3::Python) -> PyObject {
+        use bitcoin::Network::*;
+
         let chain = PyModule::import(py, "hwilib.common")
             .unwrap()
             .getattr("Chain")
             .unwrap();
-        match self {
-            HWIChain::Main => chain.get_item("MAIN").unwrap().into(),
-            HWIChain::Test => chain.get_item("TEST").unwrap().into(),
-            HWIChain::Regtest => chain.get_item("REGTEST").unwrap().into(),
-            HWIChain::Signet => chain.get_item("SIGNET").unwrap().into(),
+        match self.0 {
+            Bitcoin => chain.get_item("MAIN").unwrap().into(),
+            Testnet => chain.get_item("TEST").unwrap().into(),
+            Regtest => chain.get_item("REGTEST").unwrap().into(),
+            Signet => chain.get_item("SIGNET").unwrap().into(),
         }
     }
 }
 
 impl From<Network> for HWIChain {
     fn from(network: Network) -> Self {
-        match network {
-            Network::Bitcoin => Self::Main,
-            Network::Testnet => Self::Test,
-            Network::Regtest => Self::Regtest,
-            Network::Signet => Self::Signet,
-        }
+        Self(network)
     }
 }
 


### PR DESCRIPTION
The `HWIChain` type is only required so we can get around the orphan rule and implement `IntoPy`. We can use a wrapper type (wrapping `bitcoin::Network`) to achive this and the use plain old `Network` everywhere else. This simplifies the code and makes it more clear to the casual reader who is familiar already with `rust-bitcoin`.

Fix: #80 