### PR TITLE
Remove "use-miniscript" feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,9 +41,9 @@ jobs:
       matrix:
         rust:
           - version: 1.66.1 # STABLE
-            features: use-miniscript
+            features: miniscript
           - version: 1.48.0 # MSRV
-            features: use-miniscript
+            features: miniscript
         emulator:
           - name: trezor
           - name: ledger

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ readme = "README.md"
 
 [dependencies]
 bitcoin = { version = "0.29.1", features = ["serde", "base64"] }
-miniscript = { version = "9.0", features = ["serde"], optional = true }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 pyo3 = { version = "0.15.1", features = ["auto-initialize"] }
 base64 = "0.13.0"
+
+miniscript = { version = "9.0", features = ["serde"], optional = true }
 
 [dev-dependencies]
 serial_test = "0.6.0"
 
 [features]
 doctest = []
-use-miniscript = ["miniscript"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ mod tests {
     use bitcoin::{secp256k1, Transaction};
     use bitcoin::{TxIn, TxOut};
 
-    #[cfg(feature = "use-miniscript")]
+    #[cfg(feature = "miniscript")]
     use miniscript::{Descriptor, DescriptorPublicKey};
 
     #[test]
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     #[serial]
-    #[cfg(feature = "use-miniscript")]
+    #[cfg(feature = "miniscript")]
     fn test_get_miniscript_descriptors() {
         let client = get_first_device();
         let account = Some(10);
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     #[serial]
-    #[cfg(feature = "use-miniscript")]
+    #[cfg(feature = "miniscript")]
     fn test_display_address_with_miniscript_desc() {
         let client = get_first_device();
         let descriptor = client

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,7 @@ use pyo3::types::PyModule;
 use pyo3::{IntoPy, PyObject};
 use serde::{Deserialize, Deserializer};
 
-#[cfg(feature = "use-miniscript")]
+#[cfg(feature = "miniscript")]
 use miniscript::{Descriptor, DescriptorPublicKey};
 
 use crate::error::{Error, ErrorCode};
@@ -77,7 +77,7 @@ impl Deref for HWIPartiallySignedTransaction {
 
 pub trait ToDescriptor {}
 impl ToDescriptor for String {}
-#[cfg(feature = "use-miniscript")]
+#[cfg(feature = "miniscript")]
 impl ToDescriptor for Descriptor<DescriptorPublicKey> {}
 
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize)]


### PR DESCRIPTION
The `use-miniscript` feature just enables the optional `miniscript` dependency, this is redundant because one can enable the dependency with `cargo check --features=miniscript`.

Also the feature gating works just fine with `#[cfg(feature = "miniscript")]`