### PR TITLE
Add pin commands

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -397,7 +397,7 @@ impl HWIClient {
                 arg,
                 r#"
                 import logging
-                logging.basicConfig(level=arg)            
+                logging.basicConfig(level=arg)
                 "#
             );
             Ok(())
@@ -528,5 +528,33 @@ impl HWIClient {
                 None,
             ))
         }
+    }
+
+    pub fn prompt_pin(&self) -> Result<(), Error> {
+        Python::with_gil(|py| {
+            let func_args = (&self.hw_client,);
+            let output = self
+                .hwilib
+                .commands
+                .getattr(py, "prompt_pin")?
+                .call1(py, func_args)?;
+            let output = self.hwilib.json_dumps.call1(py, (output,))?;
+            let status: HWIStatus = deserialize_obj!(&output.to_string())?;
+            status.into()
+        })
+    }
+
+pub fn send_pin(&self, pin: String) -> Result<(), Error> {
+        Python::with_gil(|py| {
+            let func_args = (&self.hw_client, pin);
+            let output = self
+                .hwilib
+                .commands
+                .getattr(py, "send_pin")?
+                .call1(py, func_args)?;
+            let output = self.hwilib.json_dumps.call1(py, (output,))?;
+            let status: HWIStatus = deserialize_obj!(&output.to_string())?;
+            status.into()
+        })
     }
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -394,7 +394,7 @@ impl HWIClient {
                 arg,
                 r#"
                 import logging
-                logging.basicConfig(level=arg)            
+                logging.basicConfig(level=arg)
                 "#
             );
             Ok(())
@@ -525,5 +525,33 @@ impl HWIClient {
                 None,
             ))
         }
+    }
+
+    pub fn prompt_pin(&self) -> Result<(), Error> {
+        Python::with_gil(|py| {
+            let func_args = (&self.hw_client,);
+            let output = self
+                .hwilib
+                .commands
+                .getattr(py, "prompt_pin")?
+                .call1(py, func_args)?;
+            let output = self.hwilib.json_dumps.call1(py, (output,))?;
+            let status: HWIStatus = deserialize_obj!(&output.to_string())?;
+            status.into()
+        })
+    }
+
+pub fn send_pin(&self, pin: String) -> Result<(), Error> {
+        Python::with_gil(|py| {
+            let func_args = (&self.hw_client, pin);
+            let output = self
+                .hwilib
+                .commands
+                .getattr(py, "send_pin")?
+                .call1(py, func_args)?;
+            let output = self.hwilib.json_dumps.call1(py, (output,))?;
+            let status: HWIStatus = deserialize_obj!(&output.to_string())?;
+            status.into()
+        })
     }
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -544,7 +544,7 @@ impl HWIClient {
         })
     }
 
-pub fn send_pin(&self, pin: String) -> Result<(), Error> {
+    pub fn send_pin(&self, pin: String) -> Result<(), Error> {
         Python::with_gil(|py| {
             let func_args = (&self.hw_client, pin);
             let output = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ mod tests {
     use crate::types::{self, HWIDeviceType, TESTNET};
     use crate::HWIClient;
     use std::collections::BTreeMap;
+    use std::io::stdin;
     use std::str::FromStr;
-    use std::io::{stdin,};
 
     use bitcoin::bip32::{DerivationPath, KeySource};
     use bitcoin::locktime::absolute;
@@ -209,7 +209,10 @@ mod tests {
         let pk = client.get_xpub(&derivation_path, true).unwrap();
         let mut hd_keypaths: BTreeMap<secp256k1::PublicKey, KeySource> = Default::default();
         // Here device fingerprint is same as master xpub fingerprint
-        hd_keypaths.insert(pk.public_key, (device.fingerprint.unwrap(), derivation_path));
+        hd_keypaths.insert(
+            pk.public_key,
+            (device.fingerprint.unwrap(), derivation_path),
+        );
 
         let script_pubkey = address.address.assume_checked().script_pubkey();
 
@@ -489,8 +492,6 @@ mod tests {
             stdin().read_line(&mut s).expect("Please Enter Pin");
             let device_pin: String = s.split_whitespace().map(str::to_string).collect();
             client.send_pin(String::from(device_pin)).unwrap();
-
         }
     }
-
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -181,33 +181,46 @@ pub struct HWIDevice {
     pub path: String,
     pub needs_pin_sent: bool,
     pub needs_passphrase_sent: bool,
-    pub fingerprint: Fingerprint,
+    pub fingerprint: Option<Fingerprint>,
 }
 
 impl TryFrom<HWIDeviceInternal> for HWIDevice {
     type Error = Error;
+
     fn try_from(h: HWIDeviceInternal) -> Result<HWIDevice, Error> {
-        match h.error {
+        let needs_pin_sent = h.needs_pin_sent.unwrap_or_default();
+        let result = match h.error {
             Some(e) => {
                 let code = h.code.and_then(|c| ErrorCode::try_from(c).ok());
-                Err(Error::Hwi(e, code))
+                if code == Some(ErrorCode::DeviceNotReady) && needs_pin_sent {
+                    None
+                } else {
+                    Some(Error::Hwi(e, code))
+                }
             }
-            // When HWIDeviceInternal contains errors, some fields might be missing
-            // (depending on the error, hwi might not be able to know all of them).
-            // When there's no error though, all the fields must be present, and
-            // for this reason we expect here.
-            None => Ok(HWIDevice {
-                device_type: HWIDeviceType::from(
-                    h.device_type.expect("Device type should be here"),
-                ),
-                model: h.model.expect("Model should be here"),
-                path: h.path.expect("Path should be here"),
-                needs_pin_sent: h.needs_pin_sent.expect("needs_pin_sent should be here"),
-                needs_passphrase_sent: h
-                    .needs_passphrase_sent
-                    .expect("needs_passphrase_sent should be here"),
-                fingerprint: h.fingerprint.expect("Fingerprint should be here"),
-            }),
+            None => None,
+        };
+        match result {
+            Some(error) => Err(error),
+            None => {
+                let fingerprint = if needs_pin_sent {
+                    None
+                } else {
+                    Some(h.fingerprint.expect("Fingerprint should be here"))
+                };
+                Ok(HWIDevice {
+                    device_type: HWIDeviceType::from(
+                        h.device_type.expect("Device type should be here"),
+                    ),
+                    model: h.model.expect("Model should be here"),
+                    path: h.path.expect("Path should be here"),
+                    needs_pin_sent: h.needs_pin_sent.expect("needs_pin_sent should be here"),
+                    needs_passphrase_sent: h
+                        .needs_passphrase_sent
+                        .expect("needs_passphrase_sent should be here"),
+                    fingerprint,
+                })
+            }
         }
     }
 }


### PR DESCRIPTION
Adds the missing prompt_pin  and send_pin commands mentioned [here](https://github.com/bitcoindevkit/rust-hwi/issues/7) (backup appears to have already been implemented FYI).

Adding these commands required some refactoring-
They need to be called on an `HWIDevice` struct, initialized via `get_client`, however as things are `HWIDevice` requires a `Fingerprint` to initialise it, which is not available when the device is in a locked state.  Therefore I have updated its type to `Option<Fingerprint>,` with `None` being the value when in a locked state.

This also required some refactoring of the conversion of `HWIDeviceInternal` to `HWIDevice` via the `TryFrom` trait.  

when using the python HWI implementation accessing these commands is done by calling:
`./hwi.py enumerate`
from the command line, which returns:
`[{"type": "trezor", "path": "webusb:001:1:3", "label": "My Trezor", "model": "trezor_1", "needs_pin_sent": true, "needs_passphrase_sent": false, "error": "Could not open client or get fingerprint information: Trezor is locked. Unlock by using 'promptpin' and then 'sendpin'.", "code": -12}]`
 you would then reference the path referenced in this error and enter
` ./hwi.py -t trezor -d webusb:001:1:2 promptpin`
to correctly call the `promptpin` command.

However in Rust HWI paths are not directly specified, and [as things currently are](https://github.com/bitcoindevkit/rust-hwi/blob/master/src/types.rs#L190) the occurance of all Errors will prevent conversion from `HWIDeviceInternal` to `HWIDevice`, and instead return an error which contains only the error message and code (`[Err(Hwi("Could not open client or get fingerprint information: Trezor is locked. Unlock by using 'promptpin' and then 'sendpin'.", Some(-12)))]` in the example above).  

After playing around with a few approaches the cleanest and simplest to my eyes is what I have implemented here- an if statement to let this specific error pass, and then a match statement to either return the error in all other instances, or initialise the struct with the correct `Fingerprint` value.  
