### PR TITLE
ci: Fix building trezor-firmware in Docker

### DIFF
--- a/ci/Dockerfile.trezor
+++ b/ci/Dockerfile.trezor
@@ -3,10 +3,16 @@ FROM rust
 RUN rustup toolchain install nightly
 RUN rustup default nightly
 RUN apt-get update
-RUN apt-get install scons libsdl2-dev python3 python3-pip libsdl2-image-dev llvm-dev libclang-dev clang protobuf-compiler libusb-1.0-0-dev -y
-RUN git clone --recursive -b core/v2.5.3 https://github.com/trezor/trezor-firmware/ trezor-firmware
+RUN apt-get install scons libsdl2-dev python3 python3-pip python3-poetry libsdl2-image-dev llvm-dev libclang-dev clang protobuf-compiler libusb-1.0-0-dev -y
+RUN git clone --recursive -b core/v2.6.4 https://github.com/trezor/trezor-firmware/ trezor-firmware
 WORKDIR /trezor-firmware/core
-RUN pip install poetry
+
+# pyblake2 broken on 3.11, trezor-firmware does not use it but depends on it => remove it as dependency
+RUN sed -i "/pyblake.*/d" ../pyproject.toml
+
+# build wrapt 1.13.3 fails => update to 1.14.1
+RUN poetry add "wrapt==1.14.1"
+
 RUN poetry install
 RUN poetry run make build_unix
 CMD ["poetry", "run", "./emu.py", "--headless", "--slip0014", "-q"]


### PR DESCRIPTION
- installs poetry from Debian package instead of pip
- removes dependency on pyblake2 from trezor-firwmare (it's not used anywhere)
- updates to wrapt 1.14.1 since the default 1.13.3 does not build on Python 3.11
- upgrades trezor-firwmare to 2.6.4

Tests pass on my machine with this setup.

Some of the changes should go to upstream (not yet sure if I try to). Weird is that nobody is complaining about it there, even though on my machine I encountered the same failures as in the Docker build.

If stars are aligned, should fix #93.