### PR TITLE
Update version to 0.8.0, bump MSRV to 1.63.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,9 @@ jobs:
     strategy:
       matrix:
         rust:
-          - version: 1.66.1 # STABLE
+          - version: stable # STABLE
             features: miniscript
-          - version: 1.48.0 # MSRV
+          - version: 1.63.0 # MSRV
             features: miniscript
         emulator:
           - name: trezor
@@ -84,14 +84,6 @@ jobs:
         run: rustup set profile minimal
       - name: Update toolchain
         run: rustup update
-      - if: ${{matrix.rust.version}} = 1.48.0
-        name: Pin dependencies that use edition 2021
-        # serde 1.0.157 uses syn 2.0 which requires edition 2021.
-        # serde_json depends on 1.0.66
-        # once_cell v0.15.0 uses edition 2021.
-        # quote 1.0.31 uses proc-macro2 1.0.66, which requires edition 2021
-        run: cargo update -p serde_json --precise 1.0.99 && cargo update -p serde --precise 1.0.156  && cargo update -p once_cell --precise 1.14.0 && cargo update -p quote --precise 1.0.30 && cargo update -p proc-macro2 --precise 1.0.65
-
       - name: Test
         run: cargo test --features ${{ matrix.rust.features }}
       - name: Wipe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hwi"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Daniela Brozzoni <danielabrozzoni@protonmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -3,21 +3,14 @@ Rust wrapper for the [Bitcoin Hardware Wallet Interface](https://github.com/bitc
 
 <a href="https://crates.io/crates/hwi"><img alt="Crate Info" src="https://img.shields.io/crates/v/hwi.svg"/></a>
 <a href="https://docs.rs/hwi"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-hwi-green"/></a>
-<a href="https://blog.rust-lang.org/2020/02/27/Rust-1.41.1.html"><img alt="Rustc Version 1.41+" src="https://img.shields.io/badge/rustc-1.41%2B-lightgrey.svg"/></a>
+<a href="https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html"><img alt="Rustc Version 1.63+" src="https://img.shields.io/badge/rustc-1.63%2B-lightgrey.svg"/></a>
 <a href="https://discord.gg/d7NkDKm"><img alt="Chat on Discord" src="https://img.shields.io/discord/753336465005608961?logo=discord"></a>
 
 This library internally uses PyO3 to call HWI's functions. It is not a re-implementation of HWI in native Rust.
 
 ## MSRV
 
-The MSRV for this project is `1.48.0`. To build with the MSRV you will need to pin some dependencies:
-```bash
-cargo update -p serde_json --precise 1.0.99
-cargo update -p serde --precise 1.0.156
-cargo update -p once_cell --precise 1.14.0
-cargo update -p quote --precise 1.0.30
-cargo update -p proc-macro2 --precise 1.0.65
-```
+The MSRV for this project is `1.63.0`.
 
 ## Prerequisites
 


### PR DESCRIPTION
We need to publish a new version with the rust-bitcoin/miniscript version bump.

I also updated the MSRV for this project to 1.63.0 to match other BDK projects and so I could remove the version pinning that wasn't working anymore.