### PR TITLE
Depend on bitcoin v0.32.0-rc1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hwi"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Daniela Brozzoni <danielabrozzoni@protonmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -11,15 +11,51 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = { version = "0.31.0", features = ["serde", "base64"] }
+bitcoin = { version = "0.32.0-rc1", features = ["serde", "base64"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 pyo3 = { version = "0.15.1", features = ["auto-initialize"] }
 
-miniscript = { version = "11.0", features = ["serde"], optional = true }
+miniscript = { version = "12.0", features = ["serde"], optional = true }
 
 [dev-dependencies]
 serial_test = "0.6.0"
 
 [features]
 doctest = []
+
+[patch.crates-io.miniscript]
+git = "https://github.com/tcharding/rust-miniscript/"
+branch = "test-bitcoin"
+
+[patch.crates-io.bitcoind]
+git = "https://github.com/tcharding/bitcoind/"
+branch = "test-bitcoin"
+
+[patch.crates-io.bitcoincore-rpc]
+git = "https://github.com/tcharding/rust-bitcoincore-rpc"
+branch = "test-bitcoin"
+
+[patch.crates-io.base58ck]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin_hashes]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-internals]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-io]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-units]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ mod tests {
 
         let previous_txin = TxIn {
             previous_output: bitcoin::OutPoint {
-                txid: previous_tx.txid(),
+                txid: previous_tx.compute_txid(),
                 vout: Default::default(),
             },
             ..Default::default()


### PR DESCRIPTION
This is not a merge candidate, just for testing the current bitcoin release candidate.

Test the latest bitcoin release candidate. Includes bumping the version numbers so we can use this branch to test crates further up the stack.