### PR TITLE
chore(deps): upgrade `rust-bitcoin` to `0.32.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = { version = "0.31.0", features = ["serde", "base64"] }
+bitcoin = { version = "0.32", features = ["serde", "base64"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 pyo3 = { version = "0.21.2", features = ["auto-initialize"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hwi"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Daniela Brozzoni <danielabrozzoni@protonmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 pyo3 = { version = "0.21.2", features = ["auto-initialize"] }
 
-miniscript = { version = "11.0", features = ["serde"], optional = true }
+miniscript = { version = "12.0", features = ["serde"], optional = true }
 
 [dev-dependencies]
 serial_test = "0.6.0"

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -224,8 +224,9 @@ impl HWIClient {
         path: &DerivationPath,
         expert: bool,
     ) -> Result<HWIExtendedPubKey, Error> {
+        let prefixed_path = format!("m/{}", path);
         Python::with_gil(|py| {
-            let func_args = (&self.hw_client, path.to_string(), expert);
+            let func_args = (&self.hw_client, prefixed_path, expert);
             let output = self
                 .hwilib
                 .commands
@@ -242,8 +243,9 @@ impl HWIClient {
         message: &str,
         path: &DerivationPath,
     ) -> Result<HWISignature, Error> {
+        let prefixed_path = format!("m/{}", path);
         Python::with_gil(|py| {
-            let func_args = (&self.hw_client, message, path.to_string());
+            let func_args = (&self.hw_client, message, prefixed_path);
             let output = self
                 .hwilib
                 .commands
@@ -279,7 +281,7 @@ impl HWIClient {
         Python::with_gil(|py| {
             let mut p_str = py.None();
             if let Some(p) = path {
-                p_str = format!("{}/*", p).into_py(py);
+                p_str = format!("m/{}/*", p).into_py(py);
             }
             let func_args = (
                 &self.hw_client,
@@ -345,8 +347,9 @@ impl HWIClient {
         address_type: HWIAddressType,
     ) -> Result<HWIAddress, Error> {
         Python::with_gil(|py| {
+            let prefixed_path = format!("m/{}", path);
             let descriptor = py.None();
-            let func_args = (&self.hw_client, path.to_string(), descriptor, address_type);
+            let func_args = (&self.hw_client, prefixed_path, descriptor, address_type);
             let output = self
                 .hwilib
                 .commands

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ mod tests {
 
         let previous_txin = TxIn {
             previous_output: bitcoin::OutPoint {
-                txid: previous_tx.txid(),
+                txid: previous_tx.compute_txid(),
                 vout: Default::default(),
             },
             ..Default::default()


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

`partially fixes` [#1422](https://github.com/bitcoindevkit/bdk/issues/1422)

### Description

It updates the `rust-bitcoin` dependency to `0.32.0`, and the `miniscript` to `0.12.0`.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

It's open for any comments.
<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Update the `bitcoin` crate dependency to `0.32.0`
- Update the `miniscript` crate dependency to `0.12.0`
- Expliciltly format the `DerivationPath` with `m/` prefix before passing it as argument to HWI interface, the `fmt::Display` trait removed the `m/` prefix on `rust-bitcoin` `0.32.0`.

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
