### PR TITLE
Add prompt_pin and send_pin HWI commands

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -497,6 +497,36 @@ impl HWIClient {
         })
     }
 
+    /// Prompt PIN on a device
+    pub fn prompt_pin(&self) -> Result<(), Error> {
+        Python::with_gil(|py| {
+            let func_args = (&self.hw_client,);
+            let output = self
+                .hwilib
+                .commands
+                .getattr(py, "prompt_pin")?
+                .call1(py, func_args)?;
+            let output = self.hwilib.json_dumps.call1(py, (output,))?;
+            let status: HWIStatus = deserialize_obj!(&output.to_string())?;
+            status.into()
+        })
+    }
+
+    /// Send PIN to a device
+    pub fn send_pin(&self, pin: &str) -> Result<(), Error> {
+        Python::with_gil(|py| {
+            let func_args = (&self.hw_client, pin);
+            let output = self
+                .hwilib
+                .commands
+                .getattr(py, "send_pin")?
+                .call1(py, func_args)?;
+            let output = self.hwilib.json_dumps.call1(py, (output,))?;
+            let status: HWIStatus = deserialize_obj!(&output.to_string())?;
+            status.into()
+        })
+    }
+
     /// Get the installed version of hwilib. Returns None if hwi is not installed.
     pub fn get_version() -> Option<String> {
         Python::with_gil(|py| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,12 +41,12 @@ pub mod types;
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{self, HWIDeviceType, TESTNET};
+    use crate::types::{self, HWIChain, HWIDevice, HWIDeviceType, TESTNET};
     use crate::HWIClient;
     use std::collections::BTreeMap;
     use std::str::FromStr;
 
-    use bitcoin::bip32::{DerivationPath, KeySource};
+    use bitcoin::bip32::{DerivationPath, Fingerprint, KeySource};
     use bitcoin::locktime::absolute;
     use bitcoin::psbt::{Input, Output};
     use bitcoin::{secp256k1, Transaction};
@@ -433,6 +433,41 @@ mod tests {
             let client = HWIClient::get_client(&device, true, TESTNET).unwrap();
             client.wipe_device().unwrap();
         }
+    }
+
+    #[test]
+    #[serial]
+    #[ignore = "Needs a Trezor One device for the test"]
+    fn test_prompt_pin_to_trezor_device() {
+        let client = HWIClient::find_device(
+            None,
+            Some(HWIDeviceType::Trezor),
+            None,
+            false,
+            Network::Testnet,
+        )
+        .unwrap();
+        client.prompt_pin().unwrap();
+    }
+
+    #[test]
+    #[serial]
+    #[ignore = "Needs a Trezor One device for the test"]
+    fn test_send_pin_to_trezor_device() {
+        let client = HWIClient::get_client(
+            &HWIDevice {
+                device_type: HWIDeviceType::Trezor,
+                model: "trezor_1".to_string(),
+                path: "webusb:000:1:2".to_string(),
+                needs_pin_sent: true,
+                needs_passphrase_sent: false,
+                fingerprint: Fingerprint::from_str("00000000").unwrap(),
+            },
+            false,
+            HWIChain::from(Network::Testnet),
+        )
+        .unwrap();
+        client.send_pin("123456").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Add support for HWI prompt_pin and send_pin commands (for Trezor One).

Not sure there's a good way to automate testing for that with an emulator though.

Tested on a physical Trezor One.